### PR TITLE
This adds support for AsyncIterator to iterall, adding the exports:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
-node_js: 7
+node_js: 7.9
 script: npm run travis

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ export function getIterator(iterable: any): void | Iterator<any>
 export function getIteratorMethod<TValue>(
   iterable: Iterable<TValue>
 ): () => Iterator<TValue>
-export function getIteratorMethod(iterable: any): () => Iterator<any> | void
+export function getIteratorMethod(iterable: any): void | (() => Iterator<any>)
 
 export function forEach<TValue, TCollection extends Iterable<TValue>>(
   collection: TCollection,
@@ -43,3 +43,43 @@ export function createIterator<TValue>(
 ): Iterator<TValue>
 export function createIterator(collection: { length: number }): Iterator<any>
 export function createIterator(collection: any): void | Iterator<any>
+
+export var $$asyncIterator: symbol | string
+
+export function isAsyncIterable(obj: any): boolean
+
+export function getAsyncIterator(
+  asyncIterable: any
+): void | AsyncIterator<mixed>
+
+export function getAsyncIteratorMethod<TValue>(
+  asyncIterable: AsyncIterable<TValue>
+): () => AsyncIterator<TValue>
+export function getAsyncIteratorMethod(
+  asyncIterable: any
+): void | (() => AsyncIterator<mixed>)
+
+export function createAsyncIterator<TValue>(
+  collection: AsyncIterable<TValue> | Iterable<Promise<TValue>> | Iterable<TValue>
+): AsyncIterator<TValue>
+export function createAsyncIterator(
+  collection: {length: number}
+): AsyncIterator<mixed>
+export function createAsyncIterator(
+  collection: any
+): void | AsyncIterator<mixed>
+
+export function forAwaitEach<TValue, TCollection extends AsyncIterable<TValue> | Iterable<Promise<TValue>> | Iterable<TValue>>(
+  collection: TCollection,
+  callbackFn: (value: TValue, index: number, collection: TCollection) => any,
+  thisArg?: any
+): Promise<void>
+export function forAwaitEach<TCollection extends { length: number }>(
+  collection: TCollection,
+  callbackFn: (
+    value: mixed,
+    index: number,
+    collection: TCollection
+  ) => Promise<any>,
+  thisArg?: any
+): Promise<void>

--- a/index.js.flow
+++ b/index.js.flow
@@ -48,3 +48,51 @@ declare export function createIterator(collection: {
   length: number
 }): Iterator<mixed>
 declare export function createIterator(collection: any): void | Iterator<mixed>
+
+declare export var $$asyncIterator: Symbol | string
+
+declare export function isAsyncIterable(obj: any): boolean
+
+declare export function getAsyncIterator(
+  asyncIterable: any
+): void | AsyncIterator<mixed>
+
+declare export function getAsyncIteratorMethod<TValue>(
+  asyncIterable: AsyncIterable<TValue>
+): () => AsyncIterator<TValue>
+declare export function getAsyncIteratorMethod(
+  asyncIterable: any
+): void | (() => AsyncIterator<mixed>)
+declare export function createAsyncIterator<TValue>(
+  collection:
+    | AsyncIterable<TValue>
+    | Iterable<Promise<TValue>>
+    | Iterable<TValue>
+): AsyncIterator<TValue>
+declare export function createAsyncIterator(collection: {
+  length: number
+}): AsyncIterator<mixed>
+declare export function createAsyncIterator(
+  collection: any
+): void | AsyncIterator<mixed>
+
+declare export function forAwaitEach<
+  TValue,
+  TCollection:
+    | AsyncIterable<TValue>
+    | Iterable<Promise<TValue>>
+    | Iterable<TValue>
+>(
+  collection: TCollection,
+  callbackFn: (value: TValue, index: number, collection: TCollection) => any,
+  thisArg?: any
+): Promise<void>
+declare export function forAwaitEach<TCollection: { length: number }>(
+  collection: TCollection,
+  callbackFn: (
+    value: mixed,
+    index: number,
+    collection: TCollection
+  ) => Promise<any>,
+  thisArg?: any
+): Promise<void>


### PR DESCRIPTION
This adds support for AsyncIterator to iterall, adding the exports:

* $$asyncIterator
* isAsyncIterable()
* getAsyncIterator()
* getAsyncIteratorMethod()
* createAsyncIterator()
* forAwaitEach()

Calling `createAsyncIterator()` or `forAwaitEach()` assumes the existence of `Promise` in the environment.

Closes #13 
