### PR TITLE
RFC: Update flow types to allow broader input

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -12,9 +12,6 @@
 // Iterable, Iterator, AsyncIterable, and AsyncIterator so they are not
 // defined here.
 
-// Note: Flow type definitions are stricter than Typescript's due to lacking
-// non-exhaustive function overriding.
-
 declare export var $$iterator: '@@iterator'
 
 declare export function isIterable(obj: any): boolean
@@ -26,17 +23,23 @@ declare export function isCollection(obj: any): boolean
 declare export function getIterator<TValue>(
   iterable: Iterable<TValue>
 ): Iterator<TValue>
+declare export function getIterator(iterable: mixed): void | Iterator<mixed>
 
 declare export function getIteratorMethod<TValue>(
   iterable: Iterable<TValue>
 ): () => Iterator<TValue>
-
+declare export function getIteratorMethod(
+  iterable: mixed
+): void | (() => Iterator<mixed>)
 declare export function createIterator<TValue>(
   collection: Iterable<TValue>
 ): Iterator<TValue>
 declare export function createIterator(collection: {
   length: number
 }): Iterator<mixed>
+declare export function createIterator(
+  collection: mixed
+): void | Iterator<mixed>
 
 declare export function forEach<TValue, TCollection: Iterable<TValue>>(
   collection: TCollection,
@@ -56,17 +59,25 @@ declare export function isAsyncIterable(obj: any): boolean
 declare export function getAsyncIterator<TValue>(
   asyncIterable: AsyncIterable<TValue>
 ): AsyncIterator<TValue>
+declare export function getAsyncIterator(
+  asyncIterable: mixed
+): void | AsyncIterator<mixed>
 
 declare export function getAsyncIteratorMethod<TValue>(
   asyncIterable: AsyncIterable<TValue>
 ): () => AsyncIterator<TValue>
-
+declare export function getAsyncIteratorMethod(
+  asyncIterable: AsyncIterable<mixed>
+): void | (() => AsyncIterator<mixed>)
 declare export function createAsyncIterator<TValue>(
   collection: AsyncIterable<TValue> | Iterable<Promise<TValue> | TValue>
 ): AsyncIterator<TValue>
 declare export function createAsyncIterator(collection: {
   length: number
 }): AsyncIterator<mixed>
+declare export function createAsyncIterator(
+  collection: mixed
+): void | AsyncIterator<mixed>
 
 declare export function forAwaitEach<
   TValue,

--- a/index.js.flow
+++ b/index.js.flow
@@ -20,71 +20,60 @@ declare export function isArrayLike(obj: any): boolean
 
 declare export function isCollection(obj: any): boolean
 
-declare export var getIterator: (<TValue>(
-  Iterable<TValue>
-) => Iterator<TValue>) &
-  ((mixed) => void | Iterator<mixed>)
+declare export var getIterator:
+  & (<TValue>(iterable: Iterable<TValue>) => Iterator<TValue>)
+  & ((iterable: mixed) => void | Iterator<mixed>)
 
-declare export var getIteratorMethod: (<TValue>(
-  Iterable<TValue>
-) => () => Iterator<TValue>) &
-  ((mixed) => void | (() => Iterator<mixed>))
+declare export var getIteratorMethod:
+  & (<TValue>(iterable: Iterable<TValue>) => (() => Iterator<TValue>))
+  & ((iterable: mixed) => (void | (() => Iterator<mixed>)))
 
-declare export var createIterator: (<TValue>(
-  Iterable<TValue>
-) => Iterator<TValue>) &
-  (({ length: number }) => Iterator<mixed>) &
-  ((mixed) => void | Iterator<mixed>)
+declare export var createIterator:
+  & (<TValue>(collection: Iterable<TValue>) => Iterator<TValue>)
+  & ((collection: {length: number}) => Iterator<mixed>)
+  & ((collection: mixed) => (void | Iterator<mixed>))
 
-declare type Callback<TValue, TCollection> = (
-  value: TValue,
-  index: number,
-  collection: TCollection
-) => any
-
-declare export var forEach: (<TValue, TCollection: Iterable<TValue>>(
-  collection: TCollection,
-  callbackFn: Callback<TValue, TCollection>,
-  thisArg?: any
-) => void) &
-  (<TCollection: { length: number }>(
-    collection: TCollection,
-    callbackFn: Callback<mixed, TCollection>,
-    thisArg?: any
-  ) => void)
+declare export var forEach:
+  & (<TValue, TCollection: Iterable<TValue>>(
+      collection: TCollection,
+      callbackFn: (value: TValue, index: number, collection: TCollection) => any,
+      thisArg?: any
+    ) => void)
+  & (<TCollection: {length: number}>(
+      collection: TCollection,
+      callbackFn: (value: mixed, index: number, collection: TCollection) => any,
+      thisArg?: any
+    ) => void)
 
 declare export var $$asyncIterator: '@@asyncIterator'
 
 declare export function isAsyncIterable(obj: any): boolean
 
-declare export var getAsyncIterator: (<TValue>(
-  AsyncIterable<TValue>
-) => AsyncIterator<TValue>) &
-  ((mixed) => void | AsyncIterator<mixed>)
+declare export var getAsyncIterator:
+  & (<TValue>(asyncIterable: AsyncIterable<TValue>) => AsyncIterator<TValue>)
+  & ((asyncIterable: mixed) => (void | AsyncIterator<mixed>))
 
-declare export var getAsyncIteratorMethod: (<TValue>(
-  AsyncIterable<TValue>
-) => () => AsyncIterator<TValue>) &
-  ((mixed) => void | (() => AsyncIterator<mixed>))
+declare export var getAsyncIteratorMethod:
+  & (<TValue>(asyncIterable: AsyncIterable<TValue>) => (() => AsyncIterator<TValue>))
+  & ((asyncIterable: mixed) => (void | (() => AsyncIterator<mixed>)))
 
-declare export var createAsyncIterator: (<TValue>(
-  AsyncIterable<TValue> | Iterable<Promise<TValue> | TValue>
-) => AsyncIterator<TValue>) &
-  (({ length: number }) => AsyncIterator<mixed>) &
-  ((mixed) => void | AsyncIterator<mixed>)
+declare export var createAsyncIterator:
+  & (<TValue>(
+      collection:
+        | Iterable<Promise<TValue> | TValue>
+        | AsyncIterable<TValue>
+    ) => AsyncIterator<TValue>)
+  & ((collection: {length: number}) => AsyncIterator<mixed>)
+  & ((collection: mixed) => (void | AsyncIterator<mixed>))
 
-declare export var forAwaitEach: (<TValue, TCollection: AsyncIterable<TValue>>(
-  collection: TCollection,
-  callbackFn: Callback<TValue, TCollection>,
-  thisArg?: any
-) => Promise<void>) &
-  (<TValue, TCollection: Iterable<Promise<TValue> | TValue>>(
-    collection: TCollection,
-    callbackFn: Callback<TValue, TCollection>,
-    thisArg?: any
-  ) => Promise<void>) &
-  (<TCollection: { length: number }>(
-    collection: TCollection,
-    callbackFn: Callback<mixed, TCollection>,
-    thisArg?: any
-  ) => Promise<void>)
+declare export var forAwaitEach:
+  & (<TValue, TCollection: Iterable<Promise<TValue> | TValue> | AsyncIterable<TValue>>(
+      collection: TCollection,
+      callbackFn: (value: TValue, index: number, collection: TCollection) => any,
+      thisArg?: any
+    ) => Promise<void>)
+  & (<TCollection: { length: number }>(
+      collection: TCollection,
+      callbackFn: (value: mixed, index: number, collection: TCollection) => any,
+      thisArg?: any
+    ) => Promise<void>)

--- a/index.js.flow
+++ b/index.js.flow
@@ -21,20 +21,20 @@ declare export function isArrayLike(obj: any): boolean
 declare export function isCollection(obj: any): boolean
 
 declare export var getIterator:
-  & (<TValue>(iterable: Iterable<TValue>) => Iterator<TValue>)
+  & (<+TValue>(iterable: Iterable<TValue>) => Iterator<TValue>)
   & ((iterable: mixed) => void | Iterator<mixed>)
 
 declare export var getIteratorMethod:
-  & (<TValue>(iterable: Iterable<TValue>) => (() => Iterator<TValue>))
+  & (<+TValue>(iterable: Iterable<TValue>) => (() => Iterator<TValue>))
   & ((iterable: mixed) => (void | (() => Iterator<mixed>)))
 
 declare export var createIterator:
-  & (<TValue>(collection: Iterable<TValue>) => Iterator<TValue>)
+  & (<+TValue>(collection: Iterable<TValue>) => Iterator<TValue>)
   & ((collection: {length: number}) => Iterator<mixed>)
   & ((collection: mixed) => (void | Iterator<mixed>))
 
 declare export var forEach:
-  & (<TValue, TCollection: Iterable<TValue>>(
+  & (<+TValue, TCollection: Iterable<TValue>>(
       collection: TCollection,
       callbackFn: (value: TValue, index: number, collection: TCollection) => any,
       thisArg?: any
@@ -50,24 +50,22 @@ declare export var $$asyncIterator: '@@asyncIterator'
 declare export function isAsyncIterable(obj: any): boolean
 
 declare export var getAsyncIterator:
-  & (<TValue>(asyncIterable: AsyncIterable<TValue>) => AsyncIterator<TValue>)
+  & (<+TValue>(asyncIterable: AsyncIterable<TValue>) => AsyncIterator<TValue>)
   & ((asyncIterable: mixed) => (void | AsyncIterator<mixed>))
 
 declare export var getAsyncIteratorMethod:
-  & (<TValue>(asyncIterable: AsyncIterable<TValue>) => (() => AsyncIterator<TValue>))
+  & (<+TValue>(asyncIterable: AsyncIterable<TValue>) => (() => AsyncIterator<TValue>))
   & ((asyncIterable: mixed) => (void | (() => AsyncIterator<mixed>)))
 
 declare export var createAsyncIterator:
-  & (<TValue>(
-      collection:
-        | Iterable<Promise<TValue> | TValue>
-        | AsyncIterable<TValue>
+  & (<+TValue>(
+      collection: Iterable<Promise<TValue> | TValue> | AsyncIterable<TValue>
     ) => AsyncIterator<TValue>)
   & ((collection: {length: number}) => AsyncIterator<mixed>)
   & ((collection: mixed) => (void | AsyncIterator<mixed>))
 
 declare export var forAwaitEach:
-  & (<TValue, TCollection: Iterable<Promise<TValue> | TValue> | AsyncIterable<TValue>>(
+  & (<+TValue, TCollection: Iterable<Promise<TValue> | TValue> | AsyncIterable<TValue>>(
       collection: TCollection,
       callbackFn: (value: TValue, index: number, collection: TCollection) => any,
       thisArg?: any

--- a/index.js.flow
+++ b/index.js.flow
@@ -20,83 +20,71 @@ declare export function isArrayLike(obj: any): boolean
 
 declare export function isCollection(obj: any): boolean
 
-declare export function getIterator<TValue>(
-  iterable: Iterable<TValue>
-): Iterator<TValue>
-declare export function getIterator(iterable: mixed): void | Iterator<mixed>
+declare export var getIterator: (<TValue>(
+  Iterable<TValue>
+) => Iterator<TValue>) &
+  ((mixed) => void | Iterator<mixed>)
 
-declare export function getIteratorMethod<TValue>(
-  iterable: Iterable<TValue>
-): () => Iterator<TValue>
-declare export function getIteratorMethod(
-  iterable: mixed
-): void | (() => Iterator<mixed>)
-declare export function createIterator<TValue>(
-  collection: Iterable<TValue>
-): Iterator<TValue>
-declare export function createIterator(collection: {
-  length: number
-}): Iterator<mixed>
-declare export function createIterator(
-  collection: mixed
-): void | Iterator<mixed>
+declare export var getIteratorMethod: (<TValue>(
+  Iterable<TValue>
+) => () => Iterator<TValue>) &
+  ((mixed) => void | (() => Iterator<mixed>))
 
-declare export function forEach<TValue, TCollection: Iterable<TValue>>(
+declare export var createIterator: (<TValue>(
+  Iterable<TValue>
+) => Iterator<TValue>) &
+  (({ length: number }) => Iterator<mixed>) &
+  ((mixed) => void | Iterator<mixed>)
+
+declare type Callback<TValue, TCollection> = (
+  value: TValue,
+  index: number,
+  collection: TCollection
+) => any
+
+declare export var forEach: (<TValue, TCollection: Iterable<TValue>>(
   collection: TCollection,
-  callbackFn: (value: TValue, index: number, collection: TCollection) => any,
+  callbackFn: Callback<TValue, TCollection>,
   thisArg?: any
-): void
-declare export function forEach<TCollection: { length: number }>(
-  collection: TCollection,
-  callbackFn: (value: mixed, index: number, collection: TCollection) => any,
-  thisArg?: any
-): void
+) => void) &
+  (<TCollection: { length: number }>(
+    collection: TCollection,
+    callbackFn: Callback<mixed, TCollection>,
+    thisArg?: any
+  ) => void)
 
 declare export var $$asyncIterator: '@@asyncIterator'
 
 declare export function isAsyncIterable(obj: any): boolean
 
-declare export function getAsyncIterator<TValue>(
-  asyncIterable: AsyncIterable<TValue>
-): AsyncIterator<TValue>
-declare export function getAsyncIterator(
-  asyncIterable: mixed
-): void | AsyncIterator<mixed>
+declare export var getAsyncIterator: (<TValue>(
+  AsyncIterable<TValue>
+) => AsyncIterator<TValue>) &
+  ((mixed) => void | AsyncIterator<mixed>)
 
-declare export function getAsyncIteratorMethod<TValue>(
-  asyncIterable: AsyncIterable<TValue>
-): () => AsyncIterator<TValue>
-declare export function getAsyncIteratorMethod(
-  asyncIterable: AsyncIterable<mixed>
-): void | (() => AsyncIterator<mixed>)
-declare export function createAsyncIterator<TValue>(
-  collection: AsyncIterable<TValue> | Iterable<Promise<TValue> | TValue>
-): AsyncIterator<TValue>
-declare export function createAsyncIterator(collection: {
-  length: number
-}): AsyncIterator<mixed>
-declare export function createAsyncIterator(
-  collection: mixed
-): void | AsyncIterator<mixed>
+declare export var getAsyncIteratorMethod: (<TValue>(
+  AsyncIterable<TValue>
+) => () => AsyncIterator<TValue>) &
+  ((mixed) => void | (() => AsyncIterator<mixed>))
 
-declare export function forAwaitEach<
-  TValue,
-  TCollection: AsyncIterable<TValue>
->(
+declare export var createAsyncIterator: (<TValue>(
+  AsyncIterable<TValue> | Iterable<Promise<TValue> | TValue>
+) => AsyncIterator<TValue>) &
+  (({ length: number }) => AsyncIterator<mixed>) &
+  ((mixed) => void | AsyncIterator<mixed>)
+
+declare export var forAwaitEach: (<TValue, TCollection: AsyncIterable<TValue>>(
   collection: TCollection,
-  callbackFn: (value: TValue, index: number, collection: TCollection) => any,
+  callbackFn: Callback<TValue, TCollection>,
   thisArg?: any
-): Promise<void>
-declare export function forAwaitEach<
-  TValue,
-  TCollection: Iterable<Promise<TValue> | TValue>
->(
-  collection: TCollection,
-  callbackFn: (value: TValue, index: number, collection: TCollection) => any,
-  thisArg?: any
-): Promise<void>
-declare export function forAwaitEach<TCollection: { length: number }>(
-  collection: TCollection,
-  callbackFn: (value: mixed, index: number, collection: TCollection) => any,
-  thisArg?: any
-): Promise<void>
+) => Promise<void>) &
+  (<TValue, TCollection: Iterable<Promise<TValue> | TValue>>(
+    collection: TCollection,
+    callbackFn: Callback<TValue, TCollection>,
+    thisArg?: any
+  ) => Promise<void>) &
+  (<TCollection: { length: number }>(
+    collection: TCollection,
+    callbackFn: Callback<mixed, TCollection>,
+    thisArg?: any
+  ) => Promise<void>)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "flow": "flow check",
     "lint": "npm run prettier -- --write",
     "lint-check": "npm run prettier -- --list-different",
-    "prettier": "prettier --single-quote --no-semi --parser flow '*.{js,flow}'",
+    "prettier": "prettier --single-quote --no-semi '*.js'",
     "testonly": "nyc --check-coverage --statements 100 node test.js",
     "testdocs": "if [ \"$(documentation readme -dgs API | grep -vF 'up to date')\" ]; then echo 'Must run: npm run docs'; exit 1; fi;",
     "docs": "documentation readme -gs API",
@@ -41,7 +41,7 @@
   "devDependencies": {
     "coveralls": "2.13.0",
     "documentation": "4.0.0-beta5",
-    "flow-bin": "0.44.2",
+    "flow-bin": "0.45.0",
     "nyc": "10.2.0",
     "prettier": "1.2.2"
   }

--- a/test.js
+++ b/test.js
@@ -317,37 +317,24 @@ test('getIterator provides Iterator for empty String', () => {
 })
 
 test('getIterator undefined for Number', () =>
-  // $FlowExpectError
   getIterator(1) === undefined &&
-  // $FlowExpectError
   getIterator(0) === undefined &&
-  // $FlowExpectError
   getIterator(new Number(123)) === undefined && // eslint-disable-line no-new-wrappers
-  // $FlowExpectError
   getIterator(NaN) === undefined)
 
 test('getIterator undefined for Boolean', () =>
-  // $FlowExpectError
   getIterator(true) === undefined &&
-  // $FlowExpectError
   getIterator(false) === undefined &&
-  // $FlowExpectError
   getIterator(new Boolean(true)) === undefined) // eslint-disable-line no-new-wrappers
 
-test('getIterator undefined for null', () =>
-  // $FlowExpectError
-  getIterator(null) === undefined)
+test('getIterator undefined for null', () => getIterator(null) === undefined)
 
 test('getIterator undefined for undefined', () =>
-  // $FlowExpectError
   getIterator(undefined) === undefined)
 
 test('getIterator undefined for non-iterable Object', () =>
-  // $FlowExpectError
   getIterator({}) === undefined &&
-  // $FlowExpectError
   getIterator({ iterable: true }) === undefined &&
-  // $FlowExpectError
   getIterator(arrayLike()) === undefined)
 
 test('getIterator provides Iterator for iterable Object', () => {
@@ -574,11 +561,9 @@ test('forEach iterates over holey Array-like', () => {
 var createIterator = require('./').createIterator
 
 test('createIterator returns undefined for null', () =>
-  // $FlowExpectError
   createIterator(null) === undefined)
 
 test('createIterator returns undefined for undefined', () =>
-  // $FlowExpectError
   createIterator(undefined) === undefined)
 
 test('createIterator creates Iterator for string literal', () => {
@@ -624,7 +609,6 @@ test('createIterator creates Iterator for Iterator', () => {
 })
 
 test('createIterator returns undefined for incorrect Iterable', () =>
-  // $FlowExpectError
   createIterator(badIterable()) === undefined)
 
 test('createIterator creates Iterator for custom Iterable', () => {
@@ -796,33 +780,23 @@ test('getAsyncIterator provides AsyncIterator for AsyncIterable', () => {
 })
 
 test('getAsyncIterator provides undefined for Array', () =>
-  // $FlowExpectError
   getAsyncIterator(['Alpha', 'Bravo', 'Charlie']) === undefined &&
-  // $FlowExpectError
   getAsyncIterator([]) === undefined)
 
 test('getAsyncIterator provides undefined for String', () =>
-  // $FlowExpectError
   getAsyncIterator('A') === undefined &&
-  // $FlowExpectError
   getAsyncIterator('0') === undefined &&
-  // $FlowExpectError
   getAsyncIterator(new String('ABC')) === undefined && // eslint-disable-line no-new-wrappers
-  // $FlowExpectError
   getAsyncIterator('') === undefined)
 
 test('getAsyncIterator undefined for null', () =>
-  // $FlowExpectError
   getAsyncIterator(null) === undefined)
 
 test('getAsyncIterator undefined for undefined', () =>
-  // $FlowExpectError
   getAsyncIterator(undefined) === undefined)
 
 test('getAsyncIterator provides undefined for Iterable and Generator', () =>
-  // $FlowExpectError
   getAsyncIterator(iterSampleFib()) === undefined &&
-  // $FlowExpectError
   getAsyncIterator(genSampleFib()) === undefined)
 
 function nonSymbolAsyncIterable() {
@@ -868,7 +842,6 @@ test('getAsyncIteratorMethod provides function for AsyncIterable', () => {
 })
 
 test('getAsyncIteratorMethod provides undefined for Generator', () =>
-  // $FlowExpectError
   getAsyncIteratorMethod(genSampleFib()) === undefined)
 
 // createIterator
@@ -876,11 +849,9 @@ test('getAsyncIteratorMethod provides undefined for Generator', () =>
 var createAsyncIterator = require('./').createAsyncIterator
 
 test('createAsyncIterator returns undefined for null', () =>
-  // $FlowExpectError
   createAsyncIterator(null) === undefined)
 
 test('createAsyncIterator returns undefined for undefined', () =>
-  // $FlowExpectError
   createAsyncIterator(undefined) === undefined)
 
 test('createAsyncIterator creates AsyncIterator from AsyncIterable', async () => {
@@ -900,7 +871,6 @@ test('createAsyncIterator creates AsyncIterator from another AsyncIterator', () 
 })
 
 test('createAsyncIterator creates AsyncIterator for string literal', () => {
-  // $FlowFixMe expected function override to apply.
   var iterator = createAsyncIterator('ABC')
   assert(iterator)
   return Promise.all([
@@ -923,7 +893,6 @@ test('createAsyncIterator creates AsyncIterator for string literal', () => {
 })
 
 test('createAsyncIterator creates Iterator for Array', () => {
-  // $FlowFixMe expected function override to apply.
   var iterator = createAsyncIterator(['Alpha', 'Bravo', 'Charlie'])
   assert(iterator)
   return Promise.all([
@@ -1032,7 +1001,6 @@ test('forAwaitEach does not iterate over undefined', async () => {
 test('forAwaitEach iterates over string literal', async () => {
   var spy = createSpy()
   var myStr = 'ABC'
-  // $FlowFixMe expected function override to apply.
   await forAwaitEach(myStr, spy, spy)
   assert.deepEqual(spy.calls, [
     [spy, ['A', 0, myStr]],
@@ -1050,7 +1018,6 @@ test('forAwaitEach iterates over string literal with an async callback', async (
     })
   })
   var myStr = 'ABC'
-  // $FlowFixMe expected function override to apply.
   await forAwaitEach(myStr, iterSpy, spy)
   assert.deepEqual(spy.calls, [
     [spy, ['A', 0, myStr]],
@@ -1065,7 +1032,6 @@ test('forAwaitEach iterates over string literal with an async callback', async (
 test('forAwaitEach iterates over Array', async () => {
   var spy = createSpy()
   var myArray = ['Alpha', 'Bravo', 'Charlie']
-  // $FlowFixMe expected function override to apply.
   await forAwaitEach(myArray, spy, spy)
   assert.deepEqual(spy.calls, [
     [spy, ['Alpha', 0, myArray]],

--- a/test.js
+++ b/test.js
@@ -144,7 +144,7 @@ test('isIterable true for iterable Object', () => {
   isIterable(iterSampleFib()) === true
 })
 
-function* genSampleFib() /*: Iterable<number> */ {
+function* genSampleFib() /*: Generator<number, void, void> */ {
   var x = 0
   var y = 1
   while (x < 10) {


### PR DESCRIPTION
This updates flow types to what I want to support, and removes $FlowExpectError and $FlowFixMe from tests where the types should check.