### PR TITLE
Add missing parenthesis in asyncIterator example

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ Chirper.prototype[$$asyncIterator] = function () {
             resolve({ value: this.num++, done: false })
           }, 1000)
         }
-      }
+      })
     }
   }
 }


### PR DESCRIPTION
Minor change. Closing parenthesis for `Promise` was missing.