### PR TITLE
Add way to exit forAwaitEach early

### DIFF
--- a/index.js
+++ b/index.js
@@ -596,6 +596,7 @@ AsyncFromSyncIterator.prototype.next = function() {
 /**
  * Given an object which either implements the AsyncIterable protocol or is
  * Array-like, iterate over it, calling the `callback` at each iteration.
+ * Callback functions may exit iteration early by explicitly returning false.
  *
  * Use `forAwaitEach` where you would expect to use a `for-await-of` loop.
  *
@@ -648,7 +649,7 @@ function forAwaitEach(source, callback, thisArg) {
           .then(function(step) {
             if (!step.done) {
               Promise.resolve(callback.call(thisArg, step.value, i++, source))
-                .then(next)
+                .then(function(result) { return result === false ? resolve() : next() })
                 .catch(reject)
             } else {
               resolve()


### PR DESCRIPTION
Just like [lodash.forEach](https://lodash.com/docs/4.17.4#forEach), false can be returned to exit the iteration. Fixes https://github.com/leebyron/iterall/issues/21

@leebyron, is something you would consider? 

> It would be great if you wrote a PR to include some micro-benchmark results.

Not sure how to do that, but if you're ok with this, I'll at least add a normal test for it. :)