### PR TITLE
Fix: returning promises created in handlers

### DIFF
--- a/index.js
+++ b/index.js
@@ -647,7 +647,7 @@ function forAwaitEach(source, callback, thisArg) {
           .next()
           .then(function(step) {
             if (!step.done) {
-              Promise.resolve(callback.call(thisArg, step.value, i++, source))
+              return Promise.resolve(callback.call(thisArg, step.value, i++, source))
                 .then(next)
                 .catch(reject)
             } else {


### PR DESCRIPTION
See: http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it

This pull request resolved the warnings I received when using iterall with Bluebird installed as the global Promise object (`global.Promise = require('bluebird')`):

```
(node:16490) Warning: a promise was created in a handler at [REDACTED]/node_modules/iterall/index.js:650:23 but was not returned from it, see http://goo.gl/rRqMUw
    at Function.Promise.cast ([REDACTED]/node_modules/bluebird/js/release/promise.js:196:13)
    at [REDACTED]/node_modules/iterall/index.js:650:23
    at runCallback (timers.js:773:18)
    at tryOnImmediate (timers.js:734:5)
    at processImmediate [as _immediateCallback] (timers.js:711:5)
```