### PR TITLE
Add tests to illustrate early-breaking in user-code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,58 @@ function reduce (collection, reducer, initial) {
 }
 ```
 
+> How do I break out of a `forEach` or `forAwaitEach` loop early?
+
+While `for of` and `for await of` loops allow breaking out of a loop early with
+a `break` statement, the `forEach()` and `forAwaitEach()` functions (much like
+Array's `forEach`)  do not support early breaking.
+
+Similar to the "higher order" functions described above, this library can be the
+basis for this extended behavior. To support early break outs, you can use a
+wrapping function supporting early breaking by throwing a `BREAK` sentinel value
+from the callback and using a try/catch block to early break:
+
+```js
+const BREAK = {}
+
+function forEachBreakable (collection, callback) {
+  try {
+    forEach(collection, callback)
+  } catch (error) {
+    if (error !== BREAK) {
+      throw error
+    }
+  }
+}
+
+async function forAwaitEachBreakable (collection, callback) {
+  try {
+    await forAwaitEach(collection, callback)
+  } catch (error) {
+    if (error !== BREAK) {
+      throw error
+    }
+  }
+}
+
+// Example usages:
+forEachBreakable(obj, function (value) {
+  if (shouldBreakOn(value)) {
+    throw BREAK
+  }
+  console.log(value)
+})
+
+forAwaitEachBreakable(obj, async function (value) {
+  if (await shouldBreakOn(value)) {
+    throw BREAK
+  }
+  console.log(value)
+})
+```
+
+Note: This technique also works with the native Array `forEach` method!
+
 <!--
 
 NOTE TO CONTRIBUTORS

--- a/test.js
+++ b/test.js
@@ -494,6 +494,48 @@ test('forEach iterates over holey Array', () => {
   ])
 })
 
+test('forEach iterates over Array with early break', () => {
+  var BREAK = {}
+  var spy = createSpy(val => {
+    if (val === 'Bravo') {
+      throw BREAK
+    }
+  })
+  var myArray = ['Alpha', 'Bravo', 'Charlie']
+  try {
+    forEach(myArray, spy, spy)
+  } catch (e) {
+    if (e !== BREAK) {
+      throw e
+    }
+  }
+  assert.deepEqual(spy.calls, [
+    [spy, ['Alpha', 0, myArray]],
+    [spy, ['Bravo', 1, myArray]]
+  ])
+})
+
+test('forEach over Array propogates thrown error', () => {
+  var error = new Error('test')
+  var spy = createSpy(val => {
+    if (val === 'Bravo') {
+      throw error
+    }
+  })
+  var myArray = ['Alpha', 'Bravo', 'Charlie']
+  var caughtError
+  try {
+    forEach(myArray, spy, spy)
+  } catch (thrownError) {
+    caughtError = thrownError
+  }
+  assert.deepEqual(spy.calls, [
+    [spy, ['Alpha', 0, myArray]],
+    [spy, ['Bravo', 1, myArray]]
+  ])
+  assert.equal(caughtError, error)
+})
+
 test('forEach iterates over Iterator', () => {
   var spy = createSpy()
   var myArray = ['Alpha', 'Bravo', 'Charlie']
@@ -503,6 +545,28 @@ test('forEach iterates over Iterator', () => {
     [spy, ['Alpha', 0, myIterator]],
     [spy, ['Bravo', 1, myIterator]],
     [spy, ['Charlie', 2, myIterator]]
+  ])
+})
+
+test('forEach iterates over Iterator with early break', () => {
+  var BREAK = {}
+  var spy = createSpy(val => {
+    if (val === 'Bravo') {
+      throw BREAK
+    }
+  })
+  var myArray = ['Alpha', 'Bravo', 'Charlie']
+  var myIterator = getIterator(myArray)
+  try {
+    forEach(myIterator, spy, spy)
+  } catch (e) {
+    if (e !== BREAK) {
+      throw e
+    }
+  }
+  assert.deepEqual(spy.calls, [
+    [spy, ['Alpha', 0, myIterator]],
+    [spy, ['Bravo', 1, myIterator]]
   ])
 })
 
@@ -572,6 +636,27 @@ test('forEach iterates over holey Array-like', () => {
   assert.deepEqual(spy.calls, [
     [spy, ['One', 1, myArrayLike]],
     [spy, ['Three', 3, myArrayLike]]
+  ])
+})
+
+test('forEach iterates over Array-like with early break', () => {
+  var BREAK = {}
+  var spy = createSpy(val => {
+    if (val === 'Bravo') {
+      throw BREAK
+    }
+  })
+  var myArrayLike = arrayLike()
+  try {
+    forEach(myArrayLike, spy, spy)
+  } catch (e) {
+    if (e !== BREAK) {
+      throw e
+    }
+  }
+  assert.deepEqual(spy.calls, [
+    [spy, ['Alpha', 0, myArrayLike]],
+    [spy, ['Bravo', 1, myArrayLike]]
   ])
 })
 
@@ -1067,6 +1152,27 @@ test('forAwaitEach iterates over Array', async () => {
   ])
 })
 
+test('forAwaitEach iterates over Array with early break', async () => {
+  var BREAK = {}
+  var spy = createSpy(val => {
+    if (val === 'Bravo') {
+      throw BREAK
+    }
+  })
+  var myArray = ['Alpha', 'Bravo', 'Charlie']
+  try {
+    await forAwaitEach(myArray, spy, spy)
+  } catch (e) {
+    if (e !== BREAK) {
+      throw e
+    }
+  }
+  assert.deepEqual(spy.calls, [
+    [spy, ['Alpha', 0, myArray]],
+    [spy, ['Bravo', 1, myArray]]
+  ])
+})
+
 test('forAwaitEach iterates over Array of Promises', async () => {
   var spy = createSpy()
   var myArray = [
@@ -1144,6 +1250,28 @@ test('forAwaitEach iterates over custom AsyncIterable', () => {
       [spy, [2, 2, myAsyncIterable]]
     ])
   )
+})
+
+test('forAwaitEach iterates over custom AsyncIterable with early break', () => {
+  var BREAK = {}
+  var spy = createSpy(val => {
+    if (val === 1) {
+      throw BREAK
+    }
+  })
+  var myAsyncIterable = new Chirper(3)
+  return forAwaitEach(myAsyncIterable, spy, spy)
+    .catch(e => {
+      if (e !== BREAK) {
+        throw e
+      }
+    })
+    .then(() =>
+      assert.deepEqual(spy.calls, [
+        [spy, [0, 0, myAsyncIterable]],
+        [spy, [1, 1, myAsyncIterable]]
+      ])
+    )
 })
 
 test('forAwaitEach catches callback errors', () => {


### PR DESCRIPTION
Presenting this as an alternative to #32 - this has no changes to the codebase, instead just illustrates a user-code solution for the same set of tests added in that PR.

This proves that changes to the codebase are not necessary to provide this behavior, however there are certainly tradeoffs between this approach and explicit support in #32.

Here are some pros/cons relative to #32:

**Cons:**
- Verbose
- Non-trivial

**Pros:**
- No performance consequences when not using early-breaking
- No added bytes to the library
- Same technique is required to early break from native `forEach` (https://stackoverflow.com/a/2641374)


Fixes #21
Closes #29
Closes #32