### PR TITLE
[WIP] Update to flow 0.66

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
     "coveralls": "3.0.0",
     "documentation": "5.4.0",
-    "flow-bin": "0.65.0",
+    "flow-bin": "0.66.0",
     "nyc": "11.4.1",
     "prettier": "1.10.2",
     "regression": "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1776,9 +1776,9 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-flow-bin@0.65.0:
-  version "0.65.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.65.0.tgz#64ffeca27211c786e2d68508c65686ba1b8a2169"
+flow-bin@0.66.0:
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.66.0.tgz#a96dde7015dc3343fd552a7b4963c02be705ca26"
 
 flush-write-stream@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
@leebyron this error blocks upgrading `graphql-js` to `flow@0.66.0`:

> **Unable to determine module type (CommonJS vs ES) if both an export statement and module.exports are used in the same module!**

<img width="1048" alt="screen shot 2018-02-19 at 20 40 47" src="https://user-images.githubusercontent.com/1946920/36383129-6bd857a0-15b5-11e8-9bd1-8f727c9ebee6.png">
