### PR TITLE
Update to Flow v0.68

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,9 @@
 [options]
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectError
-suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(<VERSION>\\)?)\\)
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(<VERSION>\\)?)\\)?:? #[0-9]+
 module.file_ext=.js
 module.file_ext=.mjs
+
+[version]
+^0.68.0

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
     "coveralls": "3.0.0",
     "documentation": "5.4.0",
-    "flow-bin": "0.66.0",
+    "flow-bin": "0.68.0",
     "nyc": "11.4.1",
     "prettier": "1.10.2",
     "regression": "2.0.1"

--- a/test.js
+++ b/test.js
@@ -808,6 +808,7 @@ var $$asyncIterator = require('./').$$asyncIterator
 test('$$asyncIterator is always available', () => $$asyncIterator != null)
 
 test('$$asyncIterator is Symbol.asyncIterator when available', () =>
+  // $FlowIssue(>=0.68.0) #27054000
   Symbol.asyncIterator && $$asyncIterator === Symbol.asyncIterator)
 
 // Flow has trouble tracking Symbol values and computed properties.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1780,9 +1780,9 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-flow-bin@0.66.0:
-  version "0.66.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.66.0.tgz#a96dde7015dc3343fd552a7b4963c02be705ca26"
+flow-bin@0.68.0:
+  version "0.68.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.68.0.tgz#86c2d14857d306eb2e85e274f2eebf543564f623"
 
 flush-write-stream@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Summary:
This version of Flow erorrs on unknown properties. The builtin definitions do
not declare Symbol.asyncIterator, which is a Flow issue that I will fix.

I extended the error suppression comment to support versioned suppressions,
since this is only an error after 0.68.

Test Plan: flow

Reviewers: leeb

Subscribers:

Tasks:

Tags: