### PR TITLE
Change $$iterator and $$asyncIterator to unique symbols in declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@
 // Iterable, Iterator, AsyncIterable, and AsyncIterator so they are not
 // defined here. However you may need to configure TypeScript to include them.
 
-export var $$iterator: symbol
+export const $$iterator: unique symbol
 
 export function isIterable(obj: any): obj is Iterable<any>
 
@@ -45,7 +45,7 @@ export function forEach<TCollection extends { length: number }>(
   thisArg?: any
 ): void
 
-export var $$asyncIterator: symbol
+export const $$asyncIterator: unique symbol
 
 export function isAsyncIterable(obj: any): obj is AsyncIterable<any>
 


### PR DESCRIPTION
From the [docs](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html):
 > To enable treating symbols as unique literals a new type `unique symbol` is available

That seems appropriate here. Additionally, only `unique symbol`s can be referenced in types, e.g.
```typescript
import { $$asyncIterator } from 'iterall'

type IterallAsyncIterable<T> {
  [$$asyncIterator]: AsyncIterator<T>
}
```